### PR TITLE
Fixed a bug where app.js would not pass through routes/index.js before rendering html

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ const express = require('express');
 const app = express();
 
 // directories
-app.use(express.static('resources/html'));
 app.use(express.static('resources/stylesheet'));
 app.use(express.static('resources/javascript'));
 app.use(express.static('resources/images')); // temporary

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 router.get('/', (req, res) => {
-    res.sendFile('index.html');
+    res.sendFile('index.html', { root: 'resources/html' });
 });
 
 module.exports = router;

--- a/services/PCApi/routes/pyscripts/pyscripts.js
+++ b/services/PCApi/routes/pyscripts/pyscripts.js
@@ -3,7 +3,7 @@ const { PythonShell } = require('python-shell');
 /**
  * pyScript(scriptName, argv, res) opens up a python shell and executes a python script
  * 
- * @param {string} scriptName   : a string 
+ * @param {string} scriptName   : a string representing the name of the script
  * @param {any[]} argv          : an array of parameters that are passed to the script
  * @param {Response} res        : the response that is sent after the script is executed
  * 

--- a/services/PCApi/routes/pyscripts/pyscripts.js
+++ b/services/PCApi/routes/pyscripts/pyscripts.js
@@ -1,11 +1,14 @@
 const { PythonShell } = require('python-shell');
 
-// pyScript(...) opens up a python shell and executes a python script
-//
-// params 
-//      scriptName  : a string representing the name of the script 
-//      argv        : an array of parameters that are passed to the script
-//      res         : the response that is sent after the script is executed
+/**
+ * pyScript(scriptName, argv, res) opens up a python shell and executes a python script
+ * 
+ * @param {string} scriptName   : a string 
+ * @param {any[]} argv          : an array of parameters that are passed to the script
+ * @param {Response} res        : the response that is sent after the script is executed
+ * 
+ * @returns {JSON}
+ */
 function pyScript(scriptName, argv, res) {
     let options = {
         scriptPath: './routes/pyscripts/python-scripts',

--- a/services/PCApi/routes/pyscripts/python-scripts/somescript.py
+++ b/services/PCApi/routes/pyscripts/python-scripts/somescript.py
@@ -5,9 +5,7 @@ def main():
     args = sys.argv
     x = int(args[1])
     y = int(args[2])
-    print(add(x, y))
-
-def add(x, y):
-    return x+y
+    print(x + y)
+    print(x - y)
 
 main()


### PR DESCRIPTION
**Description:**
app.js would serve the static file index.html directly without first passing through routes/index.js

**Steps to reproduce the bug**
1. Add a ```console.log('hello');``` line inside the route in routes/index.js
2. Start the application with nodemon
3. The string 'hello' is not actually written to console log

**Testing**
Tested the steps described above after the fix, now it correctly writes 'hello' to the console.